### PR TITLE
add Makefile with CGO params

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+LIBWAKU_PATH=$(shell go list -m -f '{{.Dir}}' github.com/waku-org/waku-go-bindings)/third_party/nwaku/build
+CGO_LDFLAGS="-L$(LIBWAKU_PATH) -Wl,-rpath -Wl,$(LIBWAKU_PATH)"
+CGO_CFLAGS="-I$(LIBWAKU_PATH)"
+BIN=example
+
+build:
+	CGO_CFLAGS=$(CGO_CFLAGS) CGO_LDFLAGS=$(CGO_LDFLAGS) go build -o $(BIN) main.go
+
+run:
+	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):$(LIBWAKU_PATH) go run main.go
+
+clean:
+	rm -f $(BIN)
+


### PR DESCRIPTION
Both `make run` and `make build` should work without any extra configuration (if you have `libwaku.so` built as per `waku-go-bindings` readme) and resulting `./example` binary will then also work without any extra env var setup as teh CGO flags take care of setting up the linker properly